### PR TITLE
feat: 모임 전반적인 네이밍 수정, 참여가능회사그룹 저장 데이터 수정, MeetingStatus DELETE 추가

### DIFF
--- a/src/main/java/com/moa/meeting/adaptor/infrastructure/mysql/converter/BaseEnumConverter.java
+++ b/src/main/java/com/moa/meeting/adaptor/infrastructure/mysql/converter/BaseEnumConverter.java
@@ -1,16 +1,16 @@
 package com.moa.meeting.adaptor.infrastructure.mysql.converter;
 
 
-import com.moa.meeting.domain.enums.JoinGender;
+import com.moa.meeting.domain.enums.CanParticipateGender;
 import com.moa.meeting.domain.enums.MeetingStatus;
 
 
 public class BaseEnumConverter {
 
-	public static class JoinGenderConverter extends AbstractBaseEnumConverter<JoinGender, Character, String> {
+	public static class CanParticipateGenderConverter extends AbstractBaseEnumConverter<CanParticipateGender, Character, String> {
 
-		public JoinGenderConverter() {
-			super(JoinGender.class);
+		public CanParticipateGenderConverter() {
+			super(CanParticipateGender.class);
 		}
 
 	}

--- a/src/main/java/com/moa/meeting/adaptor/infrastructure/mysql/entity/MeetingEntity.java
+++ b/src/main/java/com/moa/meeting/adaptor/infrastructure/mysql/entity/MeetingEntity.java
@@ -3,7 +3,7 @@ package com.moa.meeting.adaptor.infrastructure.mysql.entity;
 
 import com.moa.meeting.adaptor.infrastructure.mysql.converter.BaseEnumConverter;
 import com.moa.meeting.domain.Meeting;
-import com.moa.meeting.domain.enums.JoinGender;
+import com.moa.meeting.domain.enums.CanParticipateGender;
 import com.moa.meeting.domain.enums.MeetingStatus;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -31,142 +31,130 @@ public class MeetingEntity extends BaseDateTime {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(name = "title", length = 40)
-	private String title;
+	@Column(name = "meeting_title", length = 40)
+	private String meetingTitle;
 
 	@Column(name = "host_user_uuid")
 	private UUID hostUserUuid;
 
 	@Column(name = "meeting_address", length = 255)
-	private String meetingAddress;
+	private String meetingPlaceAddress;
 
-	@Column(columnDefinition = "TEXT")
-	private String description;
+	@Column(name = "meeting_description", columnDefinition = "TEXT")
+	private String meetingDescription;
 
 	@Column(name = "entry_fee")
-	private Integer entryFee;   // 입장료
+	private Integer meetingEntryFee;   // 입장료
 
 	@Column(name = "meeting_datetime")
 	private LocalDateTime meetingDatetime;
 
-	@Column(columnDefinition = "TEXT", name = "refund_policy")
-	private String refundPolicy;
-
 	@Column(name = "is_fcfs")
-	private Boolean isFcfs; // 선착순 여부
+	private Boolean firstComeFirstServed; // 선착순 여부
 
 	@Column(name = "is_online")
-	private Boolean isOnline;   // 온라인 여부
-
-	@Column(name = "meeting_use")
-	private Boolean meetingUse; // 모임 사용 여부
+	private Boolean onlineStatus;   // 온라인 여부
 
 	@Column(name = "max_participant_num")
-	private Integer maxParticipantNum;  // 최대 참가자 수
+	private Integer maxParticipantsCount;  // 최대 참가자 수
 
 	@Column(name = "curr_participant_num")
-	private Integer currParticipantNum; // 현재 참가자 수
+	private Integer currentParticipantsCount; // 현재 참가자 수
 
 	@Column(name = "max_age")
-	private Integer maxAge;
+	private Integer maxAgeLimit;
 
 	@Column(name = "min_age")
-	private Integer minAge;
+	private Integer minAgeLimit;
 
-	@Column(name = "company_list", length = 255)
-	private String companyList; // 선택가능 회사 리스트, 구분자 : ','
+	@Column(name = "can_participate_company_list", length = 255)
+	private String canParticipateCompanyList; // 선택가능 회사그룹 id 리스트, 구분자 : ','
 
 	@Column(name = "entry_fee_info_id_list", length = 50)
-	private String entryFeeInfoIdList;   // 참가비 정보 항목 id 리스트, 구분자 : ','
+	private String entryFeeInfomationIdList;   // 참가비 정보 항목 id 리스트, 구분자 : ','
 
 	@Column(name = "entry_fee_info_etc_string", length = 50)
-	private String entryFeeInfoEtcString;   // 참가비 정보 기타 항목 string
+	private String entryFeeInfomationEtcString;   // 참가비 정보 기타 항목 string
 
-	@Column(name = "theme_category_id")
-	private Integer themeCategoryId;
-
-	@Column(name = "question", length = 40)
-	private String question;
+	@Column(name = "meeting_participation_question", length = 40)
+	private String meetingParticipationQuestion;
 
 	@Column(name = "header_image_url", length = 255)
-	private String headerImageUrl;
+	private String meetingHeaderImageUrl;
 
 	@Convert(converter = BaseEnumConverter.MeetingStatusConverter.class)
 	@Column(name = "meeting_status", length = 2)
 	private MeetingStatus meetingStatus;
 
-	@Convert(converter = BaseEnumConverter.JoinGenderConverter.class)
+	@Convert(converter = BaseEnumConverter.CanParticipateGenderConverter.class)
 	@Column(name = "join_gender", length = 1)
-	private JoinGender joinGender;
+	private CanParticipateGender canParticipateGender;
 
 
 	/**
 	 * 모임 생성
 	 *
-	 * @param title
+	 * @param meetingTitle
 	 * @param hostUserUuid
-	 * @param meetingAddress
-	 * @param description
-	 * @param entryFee
+	 * @param meetingPlaceAddress
+	 * @param meetingDescription
+	 * @param meetingEntryFee
 	 * @param meetingDatetime
-	 * @param refundPolicy
-	 * @param isFcfs
-	 * @param isOnline
-	 * @param maxParticipantNum
-	 * @param maxAge
-	 * @param minAge
-	 * @param companyList
-	 * @param entryFeeInfoIdList
-	 * @param entryFeeInfoEtcString
-	 * @param themeCategoryId
-	 * @param question
-	 * @param headerImageUrl
+	 * @param firstComeFirstServed
+	 * @param onlineStatus
+	 * @param maxParticipantsCount
+	 * @param maxAgeLimit
+	 * @param minAgeLimit
+	 * @param canParticipateCompanyList
+	 * @param entryFeeInfomationIdList
+	 * @param entryFeeInfomationEtcString
+	 * @param meetingParticipationQuestion
+	 * @param meetingHeaderImageUrl
 	 * @param meetingStatus
-	 * @param joinGender
+	 * @param canParticipateGender
 	 * @return MeetingEntity Meeting Domain JPA 구현체
 	 */
-	public static MeetingEntity createMeeting(String title, UUID hostUserUuid, String meetingAddress, String description, int entryFee, LocalDateTime meetingDatetime, String refundPolicy,
-		boolean isFcfs, boolean isOnline, int maxParticipantNum, int maxAge, int minAge, List<String> companyList, List<Integer> entryFeeInfoIdList, String entryFeeInfoEtcString, int themeCategoryId,
-		String question,
-		String headerImageUrl, MeetingStatus meetingStatus, JoinGender joinGender) {
+	public static MeetingEntity createMeeting(String meetingTitle, UUID hostUserUuid, String meetingPlaceAddress, String meetingDescription, int meetingEntryFee, LocalDateTime meetingDatetime,
+		boolean firstComeFirstServed, boolean onlineStatus, int maxParticipantsCount, int maxAgeLimit, int minAgeLimit, List<Integer> canParticipateCompanyList, List<Integer> entryFeeInfomationIdList,
+		String entryFeeInfomationEtcString,
+		String meetingParticipationQuestion,
+		String meetingHeaderImageUrl, MeetingStatus meetingStatus, CanParticipateGender canParticipateGender) {
 
 		String CompanyListStr = null;
-		String entryFeeInfoIdListStr = null;
+		String entryFeeInfomationIdListStr = null;
 
 		//
-		if (companyList != null) {
-			// 회사 그룹 List ->  String list to String, delemeter : ','
-			CompanyListStr = String.join(",", companyList);
+		if (canParticipateCompanyList != null) {
+			// 회사 그룹 List ->  Integer list to String, delemeter : ','
+			CompanyListStr = canParticipateCompanyList.toString().replaceAll(" ", "");   // 공백 제거
+			CompanyListStr = CompanyListStr.substring(1, CompanyListStr.length() - 1);  // [ ] 제거
 		}
-		if (entryFeeInfoIdList != null) {
+		if (entryFeeInfomationIdList != null) {
 			// 참가비 id List -> Integer list to String, delemeter : ','
-			entryFeeInfoIdListStr = entryFeeInfoIdList.toString().replaceAll(" ", "");
-			entryFeeInfoIdListStr = entryFeeInfoIdListStr.substring(1, entryFeeInfoIdListStr.length() - 1);
+			entryFeeInfomationIdListStr = entryFeeInfomationIdList.toString().replaceAll(" ", "");
+			entryFeeInfomationIdListStr = entryFeeInfomationIdListStr.substring(1, entryFeeInfomationIdListStr.length() - 1);
 		}
 
 		return MeetingEntity.builder()
-			.title(title)
+			.meetingTitle(meetingTitle)
 			.hostUserUuid(hostUserUuid)
-			.meetingAddress(meetingAddress)
-			.description(description)
-			.entryFee(entryFee)
+			.meetingPlaceAddress(meetingPlaceAddress)
+			.meetingDescription(meetingDescription)
+			.meetingEntryFee(meetingEntryFee)
 			.meetingDatetime(meetingDatetime)
-			.refundPolicy(refundPolicy)
-			.isFcfs(isFcfs)
-			.isOnline(isOnline)
-			.meetingUse(true)
-			.maxParticipantNum(maxParticipantNum)
-			.currParticipantNum(0)
-			.maxAge(maxAge)
-			.minAge(minAge)
-			.companyList(CompanyListStr)
-			.entryFeeInfoIdList(entryFeeInfoIdListStr)
-			.entryFeeInfoEtcString(entryFeeInfoEtcString)
-			.themeCategoryId(themeCategoryId)
-			.question(question)
-			.headerImageUrl(headerImageUrl)
-			.meetingStatus(meetingStatus)
-			.joinGender(joinGender)
+			.firstComeFirstServed(firstComeFirstServed)
+			.onlineStatus(onlineStatus)
+			.maxParticipantsCount(maxParticipantsCount)
+			.currentParticipantsCount(0)
+			.maxAgeLimit(maxAgeLimit)
+			.minAgeLimit(minAgeLimit)
+			.canParticipateCompanyList(CompanyListStr)
+			.entryFeeInfomationIdList(entryFeeInfomationIdListStr)
+			.entryFeeInfomationEtcString(entryFeeInfomationEtcString)
+			.meetingParticipationQuestion(meetingParticipationQuestion)
+			.meetingHeaderImageUrl(meetingHeaderImageUrl)
+			.meetingStatus(MeetingStatus.RECRUIT_IN_PROGRESS)
+			.canParticipateGender(canParticipateGender)
 			.build();
 	}
 
@@ -179,50 +167,54 @@ public class MeetingEntity extends BaseDateTime {
 	 * @return Meeting 모임 도메인
 	 */
 	public Meeting toDomain() {
-		// String으로 저장된 companyList, entryFeeInfoIdList를 List로 변환
-		String companyListStr = this.companyList;
-		String entryFeeInfoIdListStr = this.entryFeeInfoIdList;
-		List<String> convertCompanyList;
-		List<Integer> convertentryFeeInfoIdList = Collections.emptyList();
+		// String으로 저장된 canParticipateCompanyList, entryFeeInfomationIdList를 List로 변환
+		String canParticipateCompanyListStr = this.canParticipateCompanyList;
+		String entryFeeInfomationIdListStr = this.entryFeeInfomationIdList;
+		List<Integer> convertCanParticipateCompanyList = null;
+		List<Integer> convertEntryFeeInfomationIdList = Collections.emptyList();
 
-		if (companyListStr == null) {
-			// 회사그룹 없을 경우 모든 회사로 설정
-			convertCompanyList = Collections.singletonList("ALL");
-		} else {
-			convertCompanyList = Arrays.asList(companyListStr.split(",")); // 구분자 : ','
+		//		if (canParticipateCompanyListStr == null) {
+		//			// 회사그룹 없을 경우 모든 회사로 설정
+		//			convertCanParticipateCompanyListStr = Collections.singletonList("ALL");
+		//		} else {
+		//			convertCanParticipateCompanyListStr = Arrays.asList(canParticipateCompanyListStr.split(",")); // 구분자 : ','
+		//		}
+
+		if (canParticipateCompanyListStr != null) {
+			String[] canParticipateCompanyListStrArr = canParticipateCompanyListStr.split(",");
+			convertCanParticipateCompanyList = Arrays.stream(canParticipateCompanyListStrArr)    // stream of String
+				.map(Integer::valueOf) // stream of Integer
+				.collect(Collectors.toList());
 		}
 
-		if (entryFeeInfoIdListStr != null) {
-			String[] entryFeeInfoIdListStrArr = entryFeeInfoIdListStr.split(",");
-			convertentryFeeInfoIdList = Arrays.stream(entryFeeInfoIdListStrArr)    // stream of String
+		if (entryFeeInfomationIdListStr != null) {
+			String[] entryFeeInfomationIdListStrArr = entryFeeInfomationIdListStr.split(",");
+			convertEntryFeeInfomationIdList = Arrays.stream(entryFeeInfomationIdListStrArr)    // stream of String
 				.map(Integer::valueOf) // stream of Integer
 				.collect(Collectors.toList());
 		}
 
 		return Meeting.builder()
 			.id(this.id)
-			.title(this.title)
+			.meetingTitle(this.meetingTitle)
 			.hostUserUuid(this.hostUserUuid)
-			.meetingAddress(this.meetingAddress)
-			.description(this.description)
-			.entryFee(this.entryFee)
+			.meetingPlaceAddress(this.meetingPlaceAddress)
+			.meetingDescription(this.meetingDescription)
+			.meetingEntryFee(this.meetingEntryFee)
 			.meetingDatetime(this.meetingDatetime)
-			.refundPolicy(this.refundPolicy)
-			.isFcfs(this.isFcfs)
-			.isOnline(this.isOnline)
-			.meetingUse(this.meetingUse)
-			.maxParticipantNum(this.maxParticipantNum)
-			.currParticipantNum(this.currParticipantNum)
-			.maxAge(this.maxAge)
-			.minAge(this.minAge)
-			.companyList(convertCompanyList)
-			.entryFeeInfoIdList(convertentryFeeInfoIdList)
-			.entryFeeInfoEtcString(this.entryFeeInfoEtcString)
-			.themeCategoryId(this.themeCategoryId)
-			.question(this.question)
-			.headerImageUrl(this.headerImageUrl)
+			.firstComeFirstServed(this.firstComeFirstServed)
+			.onlineStatus(this.onlineStatus)
+			.maxParticipantsCount(this.maxParticipantsCount)
+			.currentParticipantsCount(this.currentParticipantsCount)
+			.maxAgeLimit(this.maxAgeLimit)
+			.minAgeLimit(this.minAgeLimit)
+			.canParticipateCompanyList(convertCanParticipateCompanyList)
+			.entryFeeInfomationIdList(convertEntryFeeInfomationIdList)
+			.entryFeeInfomationEtcString(this.entryFeeInfomationEtcString)
+			.meetingParticipationQuestion(this.meetingParticipationQuestion)
+			.meetingHeaderImageUrl(this.meetingHeaderImageUrl)
 			.meetingStatus(this.meetingStatus)
-			.joinGender(this.joinGender)
+			.canParticipateGender(this.canParticipateGender)
 			.createDatetime(this.getCreateDatetime())
 			.updateDatetime(this.getUpdateDatetime())
 			.build();

--- a/src/main/java/com/moa/meeting/adaptor/infrastructure/mysql/persistance/MeetingAdaptor.java
+++ b/src/main/java/com/moa/meeting/adaptor/infrastructure/mysql/persistance/MeetingAdaptor.java
@@ -19,26 +19,24 @@ public class MeetingAdaptor implements MeetingPort {
 	@Override
 	public Meeting createMeeting(Meeting meeting) {
 		MeetingEntity meetingEntity = meetingRepository.save(MeetingEntity.createMeeting(
-			meeting.getTitle(),
+			meeting.getMeetingTitle(),
 			meeting.getHostUserUuid(),
-			meeting.getMeetingAddress(),
-			meeting.getDescription(),
-			meeting.getEntryFee(),
+			meeting.getMeetingPlaceAddress(),
+			meeting.getMeetingDescription(),
+			meeting.getMeetingEntryFee(),
 			meeting.getMeetingDatetime(),
-			meeting.getRefundPolicy(),
-			meeting.getIsFcfs(),
-			meeting.getIsOnline(),
-			meeting.getMaxParticipantNum(),
-			meeting.getMaxAge(),
-			meeting.getMinAge(),
-			meeting.getCompanyList(),
-			meeting.getEntryFeeInfoIdList(),
-			meeting.getEntryFeeInfoEtcString(),
-			meeting.getThemeCategoryId(),
-			meeting.getQuestion(),
-			meeting.getHeaderImageUrl(),
+			meeting.getFirstComeFirstServed(),
+			meeting.getOnlineStatus(),
+			meeting.getMaxParticipantsCount(),
+			meeting.getMaxAgeLimit(),
+			meeting.getMinAgeLimit(),
+			meeting.getCanParticipateCompanyList(),
+			meeting.getEntryFeeInfomationIdList(),
+			meeting.getEntryFeeInfomationEtcString(),
+			meeting.getMeetingParticipationQuestion(),
+			meeting.getMeetingHeaderImageUrl(),
 			meeting.getMeetingStatus(),
-			meeting.getJoinGender()
+			meeting.getCanParticipateGender()
 		));
 		return meetingEntity.toDomain();
 	}

--- a/src/main/java/com/moa/meeting/adaptor/web/request/MeetingCreateReq.java
+++ b/src/main/java/com/moa/meeting/adaptor/web/request/MeetingCreateReq.java
@@ -1,7 +1,7 @@
 package com.moa.meeting.adaptor.web.request;
 
 
-import com.moa.meeting.domain.enums.JoinGender;
+import com.moa.meeting.domain.enums.CanParticipateGender;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.ToString;
@@ -16,40 +16,36 @@ import java.util.List;
 public class MeetingCreateReq {
 
 	@Schema(description = "모임 제목", nullable = false, example = "할로윈 파티!")
-	private String title;
+	private String meetingTitle;
 	@Schema(description = "주소(오프라인인 경우)", nullable = true, example = "부산시 해운대구")
-	private String meetingAddress;
+	private String meetingPlaceAddress;
 	@Schema(description = "모임 상세 설명", nullable = true, example = "할로윈 파티 오실래요?\n박쥐 쿠키, 호박타르트가 준비되어 있어요!!")
-	private String description;
+	private String meetingDescription;
 	@Schema(description = "모임 비용", nullable = false, example = "10000")
-	private Integer entryFee;
+	private Integer meetingEntryFee;
 	@Schema(description = "모임 시작 시간", nullable = false, example = "2021-10-31T19:30:00")
 	private LocalDateTime meetingDatetime;
-	@Schema(description = "환불 정책", nullable = true, example = "환불 불가")
-	private String refundPolicy;
 	@Schema(description = "선착순 여부", nullable = false, example = "true")
-	private Boolean isFcfs;
+	private Boolean firstComeFirstServed;
 	@Schema(description = "온라인 여부", nullable = false, example = "false")
-	private Boolean isOnline;
+	private Boolean onlineStatus;
 	@Schema(description = "참가 인원수", nullable = false, example = "10")
-	private Integer maxParticipantNum;
+	private Integer maxParticipantsCount;
 	@Schema(description = "최대 나이", nullable = true, example = "30")
-	private Integer maxAge;
+	private Integer maxAgeLimit;
 	@Schema(description = "최소 나이", nullable = true, example = "25")
-	private Integer minAge;
-	@Schema(description = "참가 가능한 회사 그룹 리스트", nullable = true, allowableValues = { "대기업", "공기업", "공무원", "중견기업", "그외" })
-	private List<String> companyList;
+	private Integer minAgeLimit;
+	@Schema(description = "참가 가능한 회사 그룹 리스트", nullable = true, example = "[2, 3]")
+	private List<Integer> canParticipateCompanyList;
 	@Schema(description = "참가비 정보 항목 id 리스트 (모임 비용이 있을 경우 설정될 수 있음)", nullable = true, example = "[1, 3]")
-	private List<Integer> entryFeeInfoIdList;
+	private List<Integer> entryFeeInfomationIdList;
 	@Schema(description = "참가비 정보 기타 항목 string (모임 비용이 있을 경우 설정될 수 있음)", nullable = true, example = "장식 구매 비용")
-	private String entryFeeInfoEtcString;
-	@Schema(description = "테마 카테고리 id", nullable = false, example = "1")
-	private Integer themeCategoryId;
+	private String entryFeeInfomationEtcString;
 	@Schema(description = "모임 참가시 필요한 질문(선착순 아닐 경우)", nullable = true, example = "자기소개 해주세요.")
-	private String question;
+	private String meetingParticipationQuestion;
 	@Schema(description = "모임 헤더 이미지 url", nullable = true)
-	private String headerImageUrl;
+	private String meetingHeaderImageUrl;
 	@Schema(description = "참가 가능한 성별", nullable = false, example = "BOTH", allowableValues = { "BOTH", "MAN", "WOMAN" })
-	private JoinGender joinGender;
+	private CanParticipateGender canParticipateGender;
 
 }

--- a/src/main/java/com/moa/meeting/application/ports/in/MeetingUseCase.java
+++ b/src/main/java/com/moa/meeting/application/ports/in/MeetingUseCase.java
@@ -3,7 +3,7 @@ package com.moa.meeting.application.ports.in;
 
 import com.moa.meeting.adaptor.web.request.MeetingCreateReq;
 import com.moa.meeting.application.ports.out.dto.MeetingGetDto;
-import com.moa.meeting.domain.enums.JoinGender;
+import com.moa.meeting.domain.enums.CanParticipateGender;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -19,48 +19,44 @@ public interface MeetingUseCase {
 	@Builder
 	class MeetingCreateQuery {
 
-		private String title;
+		private String meetingTitle;
 		private UUID hostUserUuid;
-		private String meetingAddress;
-		private String description;
-		private Integer entryFee;
+		private String meetingPlaceAddress;
+		private String meetingDescription;
+		private Integer meetingEntryFee;
 		private LocalDateTime meetingDatetime;
-		private String refundPolicy;
-		private Boolean isFcfs;
-		private Boolean isOnline;
-		private Integer maxParticipantNum;
-		private Integer maxAge;
-		private Integer minAge;
-		private List<String> companyList;
-		private List<Integer> entryFeeInfoIdList;
-		private String entryFeeInfoEtcString;
-		private Integer themeCategoryId;
-		private String question;
-		private String headerImageUrl;
-		private JoinGender joinGender;
+		private Boolean firstComeFirstServed;
+		private Boolean onlineStatus;
+		private Integer maxParticipantsCount;
+		private Integer maxAgeLimit;
+		private Integer minAgeLimit;
+		private List<Integer> canParticipateCompanyList;
+		private List<Integer> entryFeeInfomationIdList;
+		private String entryFeeInfomationEtcString;
+		private String meetingParticipationQuestion;
+		private String meetingHeaderImageUrl;
+		private CanParticipateGender canParticipateGender;
 
 
 		public static MeetingCreateQuery toQuery(MeetingCreateReq request, UUID userUuid) {
 			return MeetingCreateQuery.builder()
-				.title(request.getTitle())
+				.meetingTitle(request.getMeetingTitle())
 				.hostUserUuid(userUuid)
-				.meetingAddress(request.getMeetingAddress())
-				.description(request.getDescription())
-				.entryFee(request.getEntryFee())
+				.meetingPlaceAddress(request.getMeetingPlaceAddress())
+				.meetingDescription(request.getMeetingDescription())
+				.meetingEntryFee(request.getMeetingEntryFee())
 				.meetingDatetime(request.getMeetingDatetime())
-				.refundPolicy(request.getRefundPolicy())
-				.isFcfs(request.getIsFcfs())
-				.isOnline(request.getIsOnline())
-				.maxParticipantNum(request.getMaxParticipantNum())
-				.maxAge(request.getMaxAge())
-				.minAge(request.getMinAge())
-				.companyList(request.getCompanyList())
-				.entryFeeInfoIdList(request.getEntryFeeInfoIdList())
-				.entryFeeInfoEtcString(request.getEntryFeeInfoEtcString())
-				.themeCategoryId(request.getThemeCategoryId())
-				.question(request.getQuestion())
-				.headerImageUrl(request.getHeaderImageUrl())
-				.joinGender(request.getJoinGender())
+				.firstComeFirstServed(request.getFirstComeFirstServed())
+				.onlineStatus(request.getOnlineStatus())
+				.maxParticipantsCount(request.getMaxParticipantsCount())
+				.maxAgeLimit(request.getMaxAgeLimit())
+				.minAgeLimit(request.getMinAgeLimit())
+				.canParticipateCompanyList(request.getCanParticipateCompanyList())
+				.entryFeeInfomationIdList(request.getEntryFeeInfomationIdList())
+				.entryFeeInfomationEtcString(request.getEntryFeeInfomationEtcString())
+				.meetingParticipationQuestion(request.getMeetingParticipationQuestion())
+				.meetingHeaderImageUrl(request.getMeetingHeaderImageUrl())
+				.canParticipateGender(request.getCanParticipateGender())
 				.build();
 		}
 

--- a/src/main/java/com/moa/meeting/application/ports/out/dto/MeetingGetDto.java
+++ b/src/main/java/com/moa/meeting/application/ports/out/dto/MeetingGetDto.java
@@ -1,7 +1,7 @@
 package com.moa.meeting.application.ports.out.dto;
 
 
-import com.moa.meeting.domain.enums.JoinGender;
+import com.moa.meeting.domain.enums.CanParticipateGender;
 import com.moa.meeting.domain.enums.MeetingStatus;
 import lombok.Getter;
 import lombok.Setter;
@@ -17,23 +17,22 @@ import java.util.UUID;
 public class MeetingGetDto {
 
 	private Long id;
-	private String title;
+	private String meetingTitle;
 	private UUID hostUserUuid;
-	private String meetingAddress;
-	private String description;
-	private Integer entryFee;
+	private String meetingPlaceAddress;
+	private String meetingDescription;
+	private Integer meetingEntryFee;
 	private LocalDateTime meetingDatetime;
-	private String refundPolicy;
-	private Boolean isFcfs;
-	private Boolean isOnline;
-	private Integer maxParticipantNum;
-	private Integer maxAge;
-	private Integer minAge;
-	private String companyList;
-	private Integer themeCategoryId;
-	private String question;
-	private String headerImageUrl;
+	private Boolean firstComeFirstServed;
+	private Boolean onlineStatus;
+	private Integer maxParticipantsCount;
+	private Integer maxAgeLimit;
+	private Integer minAgeLimit;
+	private String canParticipateCompanyList;
+	private String entryFeeInfomationIdList;
+	private String meetingParticipationQuestion;
+	private String meetingHeaderImageUrl;
 	private MeetingStatus meetingStatus;
-	private JoinGender joinGender;
+	private CanParticipateGender canParticipateGender;
 
 }

--- a/src/main/java/com/moa/meeting/application/service/MeetingService.java
+++ b/src/main/java/com/moa/meeting/application/service/MeetingService.java
@@ -21,25 +21,23 @@ public class MeetingService implements MeetingUseCase {
 	@Override
 	public MeetingGetDto createMeeting(MeetingCreateQuery meetingCreateQuery) {
 		Meeting meeting = meetingPort.createMeeting(Meeting.saveMeeting(
-			meetingCreateQuery.getTitle(),
+			meetingCreateQuery.getMeetingTitle(),
 			meetingCreateQuery.getHostUserUuid(),
-			meetingCreateQuery.getMeetingAddress(),
-			meetingCreateQuery.getDescription(),
-			meetingCreateQuery.getEntryFee(),
+			meetingCreateQuery.getMeetingPlaceAddress(),
+			meetingCreateQuery.getMeetingDescription(),
+			meetingCreateQuery.getMeetingEntryFee(),
 			meetingCreateQuery.getMeetingDatetime(),
-			meetingCreateQuery.getRefundPolicy(),
-			meetingCreateQuery.getIsFcfs(),
-			meetingCreateQuery.getIsOnline(),
-			meetingCreateQuery.getMaxParticipantNum(),
-			meetingCreateQuery.getMaxAge(),
-			meetingCreateQuery.getMinAge(),
-			meetingCreateQuery.getCompanyList(),
-			meetingCreateQuery.getEntryFeeInfoIdList(),
-			meetingCreateQuery.getEntryFeeInfoEtcString(),
-			meetingCreateQuery.getThemeCategoryId(),
-			meetingCreateQuery.getQuestion(),
-			meetingCreateQuery.getHeaderImageUrl(),
-			meetingCreateQuery.getJoinGender()
+			meetingCreateQuery.getFirstComeFirstServed(),
+			meetingCreateQuery.getOnlineStatus(),
+			meetingCreateQuery.getMaxParticipantsCount(),
+			meetingCreateQuery.getMaxAgeLimit(),
+			meetingCreateQuery.getMinAgeLimit(),
+			meetingCreateQuery.getCanParticipateCompanyList(),
+			meetingCreateQuery.getEntryFeeInfomationIdList(),
+			meetingCreateQuery.getEntryFeeInfomationEtcString(),
+			meetingCreateQuery.getMeetingParticipationQuestion(),
+			meetingCreateQuery.getMeetingHeaderImageUrl(),
+			meetingCreateQuery.getCanParticipateGender()
 		));
 		return modelMapperBean.modelMapper().map(meeting, MeetingGetDto.class);
 	}

--- a/src/main/java/com/moa/meeting/domain/Meeting.java
+++ b/src/main/java/com/moa/meeting/domain/Meeting.java
@@ -1,7 +1,7 @@
 package com.moa.meeting.domain;
 
 
-import com.moa.meeting.domain.enums.JoinGender;
+import com.moa.meeting.domain.enums.CanParticipateGender;
 import com.moa.meeting.domain.enums.MeetingStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,30 +18,27 @@ import java.util.UUID;
 public class Meeting {
 
 	private Long id;
-	private String title;
+	private String meetingTitle;
 	private UUID hostUserUuid;
-	private String meetingAddress;
-	private String description;
-	private Integer entryFee;   // 입장료
+	private String meetingPlaceAddress;
+	private String meetingDescription;
+	private Integer meetingEntryFee;   // 입장료
 	private LocalDateTime meetingDatetime;
-	private String refundPolicy;
-	private Boolean isFcfs; // 선착순 여부
-	private Boolean isOnline;   // 온라인 여부
-	private Boolean meetingUse;
-	private Integer maxParticipantNum;  // 최대 참가자 수
-	private Integer currParticipantNum; // 현재 참가자 수
-	private Integer maxAge;
-	private Integer minAge;
-	private List<String> companyList;
-	private List<Integer> entryFeeInfoIdList;   // 참가비 정보 항목 id 리스트
-	private String entryFeeInfoEtcString;   // 참가비 정보 기타 항목 string
-	private Integer themeCategoryId;
-	private String question;
-	private String headerImageUrl;
+	private Boolean firstComeFirstServed; // 선착순 여부
+	private Boolean onlineStatus;   // 온라인 여부
+	private Integer maxParticipantsCount;  // 최대 참가자 수
+	private Integer currentParticipantsCount; // 현재 참가자 수
+	private Integer maxAgeLimit;
+	private Integer minAgeLimit;
+	private List<Integer> canParticipateCompanyList;
+	private List<Integer> entryFeeInfomationIdList;   // 참가비 정보 항목 id 리스트
+	private String entryFeeInfomationEtcString;   // 참가비 정보 기타 항목 string
+	private String meetingParticipationQuestion; // 모임 참가시 필요한 질문(선착순 아닐 경우)
+	private String meetingHeaderImageUrl;
 
 	// enum
 	private MeetingStatus meetingStatus;
-	private JoinGender joinGender;
+	private CanParticipateGender canParticipateGender;
 
 	// create, update datetime
 	private LocalDateTime createDatetime;
@@ -51,53 +48,50 @@ public class Meeting {
 	/**
 	 * 모임 생성
 	 *
-	 * @param title                 모임 제목
-	 * @param hostUserUuid          모임 개설자 uuid
-	 * @param meetingAddress        모임 주소
-	 * @param description           모임 설명
-	 * @param entryFee              모임 입장료
-	 * @param meetingDatetime       모임 시작 시간
-	 * @param refundPolicy          환불 정책
-	 * @param isFcfs                선착순 여부
-	 * @param isOnline              온라인 여부
-	 * @param maxParticipantNum     최대 참가자 수
-	 * @param maxAge                최대 나이
-	 * @param minAge                최소 나이
-	 * @param companyList           참가 가능한 회사 그룹 리스트
-	 * @param entryFeeInfoIdList    참가비 정보 항목 id 리스트 (모임 비용이 있을 경우 설정될 수 있음)
-	 * @param entryFeeInfoEtcString 참가비 정보 기타 항목 string (모임 비용이 있을 경우 설정될 수 있음)
-	 * @param themeCategoryId       테마 카테고리 id
-	 * @param question              모임 참가시 필요한 질문(선착순 아닐 경우)
-	 * @param headerImageUrl        모임 헤더 이미지 url
-	 * @param joinGender            참가 가능한 성별
-	 * @return Meeting Meeting Domain
+	 * @param meetingTitle                 모임 제목
+	 * @param hostUserUuid                 모임 개설자 uuid
+	 * @param meetingPlaceAddress          모임 주소
+	 * @param meetingDescription           모임 설명
+	 * @param meetingEntryFee              모임 입장료
+	 * @param meetingDatetime              모임 시작 시간
+	 * @param firstComeFirstServed         선착순 여부
+	 * @param onlineStatus                 온라인 여부
+	 * @param maxParticipantsCount         최대 참가자 수
+	 * @param maxAgeLimit                  최대 나이
+	 * @param minAgeLimit                  최소 나이
+	 * @param canParticipateCompanyList    참가 가능한 회사 그룹 리스트
+	 * @param entryFeeInfomationIdList     참가비 정보 항목 id 리스트 (모임 비용이 있을 경우 설정될 수 있음)
+	 * @param entryFeeInfomationEtcString  참가비 정보 기타 항목 string (모임 비용이 있을 경우 설정될 수 있음)
+	 * @param meetingParticipationQuestion 모임 참가시 필요한 질문(선착순 아닐 경우)
+	 * @param meetingHeaderImageUrl        모임 헤더 이미지 url
+	 * @param canParticipateGender         참가 가능한 성별
+	 * @return Meeting Domain
 	 */
-	public static Meeting saveMeeting(String title, UUID hostUserUuid, String meetingAddress, String description, int entryFee, LocalDateTime meetingDatetime, String refundPolicy,
-		boolean isFcfs, boolean isOnline, int maxParticipantNum, int maxAge, int minAge, List<String> companyList, List<Integer> entryFeeInfoIdList, String entryFeeInfoEtcString, int themeCategoryId,
-		String question,
-		String headerImageUrl, JoinGender joinGender) {
+	public static Meeting saveMeeting(String meetingTitle, UUID hostUserUuid, String meetingPlaceAddress, String meetingDescription, int meetingEntryFee, LocalDateTime meetingDatetime,
+		boolean firstComeFirstServed, boolean onlineStatus, int maxParticipantsCount, int maxAgeLimit, int minAgeLimit, List<Integer> canParticipateCompanyList, List<Integer> entryFeeInfomationIdList,
+		String entryFeeInfomationEtcString,
+		String meetingParticipationQuestion,
+		String meetingHeaderImageUrl, CanParticipateGender canParticipateGender) {
 		return Meeting.builder()
-			.title(title)
+			.meetingTitle(meetingTitle)
 			.hostUserUuid(hostUserUuid)
-			.meetingAddress(meetingAddress)
-			.description(description)
-			.entryFee(entryFee)
+			.meetingPlaceAddress(meetingPlaceAddress)
+			.meetingDescription(meetingDescription)
+			.meetingEntryFee(meetingEntryFee)
 			.meetingDatetime(meetingDatetime)
-			.refundPolicy(refundPolicy)
-			.isFcfs(isFcfs)
-			.isOnline(isOnline)
-			.maxParticipantNum(maxParticipantNum)
-			.currParticipantNum(0)
-			.maxAge(maxAge)
-			.minAge(minAge)
-			.companyList(companyList)
-			.entryFeeInfoIdList(entryFeeInfoIdList)
-			.entryFeeInfoEtcString(entryFeeInfoEtcString)
-			.themeCategoryId(themeCategoryId)
-			.question(question)
-			.headerImageUrl(headerImageUrl)
+			.firstComeFirstServed(firstComeFirstServed)
+			.onlineStatus(onlineStatus)
+			.maxParticipantsCount(maxParticipantsCount)
+			.currentParticipantsCount(0)
+			.maxAgeLimit(maxAgeLimit)
+			.minAgeLimit(minAgeLimit)
+			.canParticipateCompanyList(canParticipateCompanyList)
+			.entryFeeInfomationIdList(entryFeeInfomationIdList)
+			.entryFeeInfomationEtcString(entryFeeInfomationEtcString)
+			.meetingParticipationQuestion(meetingParticipationQuestion)
+			.meetingHeaderImageUrl(meetingHeaderImageUrl)
 			.meetingStatus(MeetingStatus.RECRUIT_IN_PROGRESS)
-			.joinGender(joinGender)
+			.canParticipateGender(canParticipateGender)
 			.build();
 	}
 

--- a/src/main/java/com/moa/meeting/domain/enums/CanParticipateGender.java
+++ b/src/main/java/com/moa/meeting/domain/enums/CanParticipateGender.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public enum JoinGender implements BaseEnum<Character, String> {
+public enum CanParticipateGender implements BaseEnum<Character, String> {
 	BOTH('B', "둘다"),
 	MAN('M', "남자"),
 	WOMAN('W', "여자");

--- a/src/main/java/com/moa/meeting/domain/enums/MeetingStatus.java
+++ b/src/main/java/com/moa/meeting/domain/enums/MeetingStatus.java
@@ -10,9 +10,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum MeetingStatus implements BaseEnum<String, String> {
 	RECRUIT_IN_PROGRESS("RI", "모집중"),
-	RECRUIT_DONE("RD", "모집 완료"),
+	RECRUIT_END("RE", "모집 완료"),
 	MEETING_END("E", "종료"),
-	MEETING_CANCEL("MC", "취소");
+	MEETING_CANCEL("MC", "취소"),
+	DELETE("D", "삭제");
 
 	private final String code;
 	private final String title;


### PR DESCRIPTION
- 회사그룹명 리스트 -> 회사그룹id리스트 (List<String> companyList -> List<Integer> canParticipateCompanyList)
- 명확한 네이밍으로 수정

name: 🚀 Pull Request

### PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정

### 변경 사항 요약
- [ ] 버그수정
- [x] Feature
- [x] 코드 스타일 변경 ( ex. 형식,지역 변수 )
- [ ] 리팩토링 ( ex. 기능변경없음, API 변경 없음 )
- [ ] 빌드 관련 변경 사항
- [ ] CI 관련 변경 사항
- [ ] 문서 내용 변경
- [ ] 기타

### 변경 사유
명확하지 않은 네이밍
참여가능한 회사리스트를 string 문자열로 넣어서 관리 어려움 예상

### 변경된 내용
참여가능회사그룹 저장 데이터 수정
- 회사그룹명 리스트 -> 회사그룹id리스트 
- List<String> companyList -> List<Integer> canParticipateCompanyList

MeetingStatus DELETE 추가

Meeting 도메인 네이밍 수정 및 그에 따른 전반적인 네이밍 수정
- title -> meetingTitle
- meetingAddress -> meetingPlaceAddress 
- description -> meetingDescription
- entryFee -> meetingEntryFee
- isFcfs -> firstComeFirstServed (약어 사용 제한)
- isOnline -> onlineStatus (다른 함수등 충돌날 수 있는 is prefix 제거 )
- maxParticipantNum -> maxParticipantsCount ('Count'는 보통 개수를 세는 데 사용되며, 'Number'는 보통 숫자나 번호임. ex: 1번째 참가자)
- currParticipantNum -> currentParticipantsCount
- maxAge -> maxAgeLimit (현재 참가자 중 최대 나이라고 오인될 수 있어 limit로 명시함, max만 약어 사용)
- minAge -> minAgeLimit (상동)
- companyList -> canParticipateCompanyList
- entryFeeInfoIdList -> entryFeeInfomationIdList
- entryFeeInfoEtcString -> entryFeeInfomationEtcString (약어 사용 제한)
- question -> meetingParticipationQuestion
- headerImageUrl -> meetingHeaderImageUrl
- joinGender -> canParticipateGender

### 관련 이슈


### 테스트 방법


### 추가 정보


### 체크리스트
- [x] 적절한 브랜치로 요청이 제출되었는가?
- [x] 관련 문서를 업데이트하였는가?
